### PR TITLE
DLT: Remove Q_ASSERT about app registration

### DIFF
--- a/src/geniviextras/qdltregistration.cpp
+++ b/src/geniviextras/qdltregistration.cpp
@@ -93,8 +93,6 @@ void QDltRegistrationPrivate::registerCategory(const QLoggingCategory *category,
 
 void QDltRegistrationPrivate::registerCategory(CategoryInfo &info)
 {
-    Q_ASSERT_X(m_dltAppRegistered, "registerCategory", "A DLT Application needs to be registered before registering a Logging Category");
-
 #if GENIVIEXTRAS_DEBUG
     std::cout << "REGISTERING CONTEXT " << info.m_ctxName.constData() << std::endl;
 #endif


### PR DESCRIPTION
The current version of DLT does not require that the app is registered before
contexts can be registered so the Q_ASSERT does not make sense.