### PR TITLE
Fix make errors for Qt5

### DIFF
--- a/src/ivicore/qiviservicemanager.cpp
+++ b/src/ivicore/qiviservicemanager.cpp
@@ -305,14 +305,14 @@ void QIviServiceManagerPrivate::addBackend(Backend *backend)
     const QString newBackendFile = backend->metaData.value(fileNameLiteral).toString();
     const QString newBackendFileBase = qtivi_helper::backendBaseName(newBackendFile);
     const QStringList ifaceList = backend->metaData.value(interfacesLiteral).toStringList();
-    const QSet<QString> newInterfaces = QSet<QString>(ifaceList.begin(), ifaceList.end());
+    const QSet<QString> newInterfaces = QSet<QString>::fromList(ifaceList);
 
     bool addBackend = true;
     if (!newBackendFile.isEmpty()) {
         for (int i = 0; i < m_backends.count(); i++) {
             Backend *b = m_backends[i];
             const QStringList curIfaceList = backend->metaData.value(interfacesLiteral).toStringList();
-            const QSet<QString> interfaces = QSet<QString>(curIfaceList.begin(), curIfaceList.end());
+	    const QSet<QString> interfaces = QSet<QString>::fromList(curIfaceList);
             if (interfaces == newInterfaces && b->name == backend->name) {
                 const QString fileName = b->metaData.value(fileNameLiteral).toString();
                 if (fileName == newBackendFile) {

--- a/src/plugins/ivimedia/media_simulator/mediaplayerbackend.cpp
+++ b/src/plugins/ivimedia/media_simulator/mediaplayerbackend.cpp
@@ -98,7 +98,7 @@ void MediaPlayerBackend::initialize()
 void MediaPlayerBackend::play()
 {
     qCDebug(media) << Q_FUNC_INFO;
-    qCDebug(media) << m_player->media().request().url();
+    qCDebug(media) << m_player->media().canonicalUrl();
     m_requestedState = QIviMediaPlayer::Playing;
     m_player->play();
 }


### PR DESCRIPTION
I found 2 errors on make process.

(1) 
qiviservicemanager.cpp:308:89: error: no matching function for call to ‘QSet<QString>::QSet(QList<QString>::const_iterator, QList<QString>::const_iterator)’
     const QSet<QString> newInterfaces = QSet<QString>(ifaceList.begin(), ifaceList.end());

iviservicemanager.cpp:315:100: error: no matching function for call to ‘QSet<QString>::QSet(QList<QString>::const_iterator, QList<QString>::const_iterator)’
             const QSet<QString> interfaces = QSet<QString>(curIfaceList.begin(), curIfaceList.end());
(2)
mediaplayerbackend.cpp:101:41: error: ‘class QMediaContent’ has no member named ‘request’
     qCDebug(media) << m_player->media().request().url();

======================================================

I fixed them based on Qt5 supported functions. I hope you to check them.

======================================================

My system environments are below: 

Ubuntu 18.04.3 LTS
QMake version 3.1, Using Qt version 5.13.2

Qt GENIVI Extras:
  DLT .................................... yes
  DLT > 2.12 ............................. yes
Qt IVI Core:
  Python3:
    Executable ........................... /usr/bin/python3
    Version .............................. 3.6.8
    virtualenv ........................... yes
    System QFace ......................... yes
  IVI Generator .......................... yes
  QtRemoteObjects Support ................ yes
Qt IVI VehicleFunctions:
  Qt Remote Objects Simulation Server .... yes
  Backends:
    Simulation Backend ................... yes
    Qt Remote Objects Backend ............ yes
Qt IVI Media:
  taglib ................................. yes
    Using system taglib .................. no
  Mediaplayer Qt Remote Objects Simulation Server . yes
  Backends:
    Mediaplayer Simulation Backend ....... yes
    Mediaplayer Qt Remote Objects Backend . yes
    Tuner Simulation Backend ............. yes

